### PR TITLE
Fix bug because of blink/chromium merge

### DIFF
--- a/app/scripts/timelineurl.js
+++ b/app/scripts/timelineurl.js
@@ -14,47 +14,34 @@ class TimelineUrl {
 		this.outputUrl = undefined;
 
 		this.isUrlCORS = false;
-		this.revInfo = {};
+		this.revs = {};
 
 		this.generateUrl();
 	}
 
 	getRevs() {
 		var chromeVersion = navigator.appVersion.replace(/.+Chrome\/(.+) .+/, '$1');
+		var url = 'https://omahaproxy.appspot.com/revision.json?version=' + chromeVersion;
 
-		var revInfo = {};
-		var revUrls = ['https://omahaproxy.appspot.com/revision.json?version=',
-			'https://omahaproxy.appspot.com/webkit.json?version='];
-
-		// take our two URLs, fetch them in parallel, parse to JSON, and merge.
-		return revUrls.map(function (url) {
-			return fetch(url + chromeVersion);
-		}).reduce(function handleJSON(chain, revPromise) {
-			return revPromise.then(function (payload) {
-				return payload.json();
-			}).then(function (json) {
-				return Object.assign(revInfo, json);
-			});
-		}, Promise.resolve()).then(function(revInfo){
-			// {"chromium_base_position":"338390","blink_position":"198714", …
-			this.revInfo = revInfo;
+		return fetch(url).then(function (payload) {
+			return payload.json();
+		}).then(function (revs) {
+			this.revs = revs;
 		}.bind(this));
-
 	}
 
 	getUrl(url) {
-
-		var chromeRev = this.revInfo.chromium_base_position;
-		var blinkRev = this.revInfo.blink_position;
+		var position = this.revs.chromium_base_position;
+		var commit = this.revs.chromium_base_commit;
 
 		return [
 			this.isUrlCORS ? 'https://frontend.chrome-dev.tools/serve_rev/@' :
 				'chrome-devtools://devtools/remote/serve_rev/@',
 
-			blinkRev, // e.g. 198714
+			commit, // e.g. 198714
 
 			// Devtools previously used devtools.html : codereview.chromium.org/1144393004/
-			chromeRev < 332419 ? '/devtools.html' : '/inspector.html',
+			position < 332419 ? '/devtools.html' : '/inspector.html',
 
 			'?loadTimelineFromURL=', url
 		].join('');

--- a/app/scripts/timelineurl.js
+++ b/app/scripts/timelineurl.js
@@ -35,9 +35,7 @@ class TimelineUrl {
 			}).then(function (json) {
 				return Object.assign(revInfo, json);
 			});
-		}, Promise.resolve());
-
-		.then(function(revInfo){
+		}, Promise.resolve()).then(function(revInfo){
 			// {"chromium_base_position":"338390","blink_position":"198714", …
 			this.revInfo = revInfo;
 		}.bind(this));
@@ -69,7 +67,7 @@ class TimelineUrl {
 			mode: 'cors',
 			method: 'HEAD'
 		}).then(function (resp) {
-			return this.isUrlCORS = true;
+			this.isUrlCORS = true;
 		}.bind(this))
 		.catch(function (err) {
 			return 'chill';  // this.isUrlCORS remains false

--- a/app/scripts/timelineurl.js
+++ b/app/scripts/timelineurl.js
@@ -31,7 +31,6 @@ class TimelineUrl {
 	}
 
 	getUrl(url) {
-		var position = this.revs.chromium_base_position;
 		var commit = this.revs.chromium_base_commit;
 
 		return [
@@ -40,8 +39,8 @@ class TimelineUrl {
 
 			commit, // e.g. 198714
 
-			// Devtools previously used devtools.html : codereview.chromium.org/1144393004/
-			position < 332419 ? '/devtools.html' : '/inspector.html',
+			// Previously `devtools.html` was used instead: codereview.chromium.org/1144393004/
+			'/inspector.html',
 
 			'?loadTimelineFromURL=', url
 		].join('');


### PR DESCRIPTION
This fixes https://github.com/ChromeDevTools/timeline-url/issues/21.

This version works in Canary but not in stable (yet). @paulirish Do you consider that a problem? It's definitely fixable but might add some clutter to the code. Given that (I think) it was always recommended for developers to use canary and we never really showed much people about this extension I don't think it's big of a problem. 